### PR TITLE
Don't test with Ruby 2.3 any more.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
- - 2.3
  - 2.5
  - 2.6
 before_install:


### PR DESCRIPTION
Ruby 2.3 is old and we don't use it, so stop testing on it. Prompted by the test failures in https://github.com/NoRedInk/first_after_created_at/pull/11.